### PR TITLE
screw hot reload

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -41,7 +41,7 @@ services:
     command: >
       sh -c "
         cd nutrinova-api/NutrinovaApi
-        dotnet watch run
+        dotnet watch run --non-interactive --no-hot-reload
         "
     ports:
       - "5000:5000"

--- a/nutrinova-api/NutrinovaApi/Program.cs
+++ b/nutrinova-api/NutrinovaApi/Program.cs
@@ -32,7 +32,6 @@ public class Program
 
         app.MapControllers();
 
-        Console.WriteLine(app.Environment);
         app.Run();
     }
 }


### PR DESCRIPTION
Adding these to the dotnet watch run command in the devcontainer will make the api just restart on a change instead of trying to hot reload. It restarts fast enough, and its really annoying to have to restart the container everytime hot reload doesnt work, which seems like > 50% of the time.