### PR TITLE
Add a nicer fallback page for errors

### DIFF
--- a/nutrinova-ui/src/app/(authorized)/account/page.tsx
+++ b/nutrinova-ui/src/app/(authorized)/account/page.tsx
@@ -6,6 +6,7 @@ export const metadata = {
 };
 
 export default function AccountPage() {
+  throw new Error('Your Mom!');
   return (
     <PageContainer title={metadata.title}>
       <Typography variant={"h3"}>Account</Typography>

--- a/nutrinova-ui/src/app/(authorized)/account/page.tsx
+++ b/nutrinova-ui/src/app/(authorized)/account/page.tsx
@@ -6,7 +6,6 @@ export const metadata = {
 };
 
 export default function AccountPage() {
-  throw new Error('Your Mom!');
   return (
     <PageContainer title={metadata.title}>
       <Typography variant={"h3"}>Account</Typography>

--- a/nutrinova-ui/src/app/error.tsx
+++ b/nutrinova-ui/src/app/error.tsx
@@ -1,0 +1,62 @@
+'use client'
+import React from 'react';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import { useRouter } from 'next/navigation';
+
+const ErrorPage = ({ error, reset }: {
+    error: Error, reset: () => void;
+}) => {
+    const router = useRouter();
+
+    return (
+        <Box
+            display="flex"
+            flexDirection="column"
+            alignItems="center"
+            justifyContent="center"
+            height="100vh"
+            padding="24px"
+        >
+            <Typography variant="h6" color="error" fontWeight="bold">
+                There was a problem
+            </Typography>
+
+            <Typography
+                variant="h4"
+                marginTop="16px"
+                color="textPrimary"
+                fontWeight="bold"
+            >
+                {error.message}
+            </Typography>
+
+            <Typography variant="h6" marginTop="24px" color="textSecondary">
+                Please try again later or contact support if the problem persists.
+            </Typography>
+
+            <Box
+                marginTop="40px"
+                display="flex"
+                gap="24px"
+            >
+                <Button
+                    variant="contained"
+                    color="primary"
+                    onClick={() => {
+                        reset();
+                    }}
+                >
+                    Try again
+                </Button>
+
+                <Button onClick={() => router.push("/")} variant="outlined" color="primary">
+                    Go back home
+                </Button>
+            </Box>
+        </Box>
+    );
+}
+
+export default ErrorPage;


### PR DESCRIPTION
This is just a last fallback page so when there are errors it's easier to try again or navigate away, Especially in production. Error pages act like layouts where they will apply to children of the folder it is in, but I guess they override each other if you put one lower down the folder tree.

You can pass in a reset function as a prop to let the user retry whatever action failed.

We could maybe do toasts with react query later if we don't want a request failing to completely take the user out of what they are doing.

![image](https://github.com/Cwighty/nutrinova/assets/59291368/52748c20-b491-44e5-a4df-1e8676851590)
