### PR TITLE
Simply sign out when auth expires

### DIFF
--- a/nutrinova-ui/src/components/providers/QueryClientNextProvider.tsx
+++ b/nutrinova-ui/src/components/providers/QueryClientNextProvider.tsx
@@ -6,11 +6,12 @@ import { Toaster, toast } from "react-hot-toast";
 
 const queryClient = new QueryClient({
   queryCache: new QueryCache({
-    onError: async (error: unknown) => {
+    onError: async (error: Error) => {
       if (error instanceof Error) {
         if (error.message.includes("401")) {
           toast.error("You are not authorized to perform this action. Please sign out and in again.");
           await signOut();
+          return;
         }
         toast.error("There was an error with your request: " + error.message);
       } else {

--- a/nutrinova-ui/src/components/providers/QueryClientNextProvider.tsx
+++ b/nutrinova-ui/src/components/providers/QueryClientNextProvider.tsx
@@ -1,14 +1,16 @@
 'use client'
 import { QueryCache, QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { signOut } from 'next-auth/react';
 import React, { ReactNode } from 'react'
 import { Toaster, toast } from "react-hot-toast";
 
 const queryClient = new QueryClient({
   queryCache: new QueryCache({
-    onError: (error: unknown) => {
+    onError: async (error: unknown) => {
       if (error instanceof Error) {
         if (error.message.includes("401")) {
           toast.error("You are not authorized to perform this action. Please sign out and in again.");
+          await signOut();
         }
         toast.error("There was an error with your request: " + error.message);
       } else {


### PR DESCRIPTION
## **User description**
Im going to see if i can get refresh tokens working but this is a intermediary fix


___

## **Type**
enhancement, bug_fix


___

## **Description**
- Enhanced error handling in `QueryClientNextProvider` to automatically sign out the user upon encountering a 401 unauthorized error.
- Utilized `next-auth/react` for signing out, improving user experience by ensuring users are not stuck in an unauthorized state.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>QueryClientNextProvider.tsx</strong><dd><code>Enhance Authorization Error Handling with Automatic Sign Out</code></dd></summary>
<hr>
      
nutrinova-ui/src/components/providers/QueryClientNextProvider.tsx

<li>Added automatic sign out using <code>next-auth/react</code> when a 401 error is <br>encountered.<br> <li> Enhanced error handling in <code>QueryClient</code> to include async sign out on <br>authorization errors.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Cwighty/nutrinova/pull/145/files#diff-0783640451643dc3bbea602d6434a3096baf092ef0e06b4e0fe3a402b9f0b483">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

