### PR TITLE
Fix overuse of session, make refresh tokens more reliable

### DIFF
--- a/nutrinova-ui/src/app/(authorized)/patients/_components/PatientSelector.tsx
+++ b/nutrinova-ui/src/app/(authorized)/patients/_components/PatientSelector.tsx
@@ -31,7 +31,6 @@ export const PatientSelector = () => {
   }
 
   const patientName = `${selectedPatient?.firstname} ${selectedPatient?.lastname}`;
-  console.log(`here is the image ${selectedPatient?.base64image}`)
   return (
     <>
       <Typography variant="button" sx={{ mx: 2 }}>{selectedPatient ? patientName : <></>}</Typography>

--- a/nutrinova-ui/src/app/(authorized)/patients/patientHooks.tsx
+++ b/nutrinova-ui/src/app/(authorized)/patients/patientHooks.tsx
@@ -27,14 +27,12 @@ const getAllPatients = async () => {
   const response = await apiClient.get<Patient[]>('/patient/all-patients');
   const res = response.data.map(async (patient) => {
     if (!patient?.hasPicture) {
-      console.log("here is the image in the get all patients", "no image found")
       return {
         ...patient,
         base64image: ''
       } as Patient;
     } else {
       const image = await getPatientImage(patient?.id ?? '');
-      console.log("here is the image in the get all patients", image);
       return {
         ...patient,
         base64image: `${image as string}`
@@ -42,7 +40,6 @@ const getAllPatients = async () => {
     }
   });
   const awaitedRes = await Promise.all(res)
-  console.log("here is the res", awaitedRes);
   return awaitedRes;
 };
 

--- a/nutrinova-ui/src/app/layout.tsx
+++ b/nutrinova-ui/src/app/layout.tsx
@@ -1,7 +1,5 @@
 import type { Metadata } from "next";
-import { Session, getServerSession } from "next-auth";
 import { MUIThemeProvider } from "@/context/ThemeContext";
-import { NextAuthSessionProvider } from "@/components/providers/SessionProvider";
 import { QueryClientNextProvider } from "@/components/providers/QueryClientNextProvider";
 import { PatientProvider } from "@/components/providers/PatientProvider";
 import { ChatBotProvider } from "@/context/ChatBotContext";
@@ -11,24 +9,21 @@ export const metadata: Metadata = {
   description: "NutriNova",
 };
 
-export default async function RootLayout({
+export default function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const session = (await getServerSession()) as Session;
   return (
     <html lang="en">
       <body>
-        <NextAuthSessionProvider session={session}>
-          <QueryClientNextProvider>
-            <MUIThemeProvider>
-                <ChatBotProvider>
-                  <PatientProvider>{children}</PatientProvider>
-                </ChatBotProvider>
-            </MUIThemeProvider>
-          </QueryClientNextProvider>
-        </NextAuthSessionProvider>
+        <QueryClientNextProvider>
+          <MUIThemeProvider>
+            <ChatBotProvider>
+              <PatientProvider>{children}</PatientProvider>
+            </ChatBotProvider>
+          </MUIThemeProvider>
+        </QueryClientNextProvider>
       </body>
     </html>
   );

--- a/nutrinova-ui/src/components/PageBar.tsx
+++ b/nutrinova-ui/src/components/PageBar.tsx
@@ -22,7 +22,7 @@ export interface PageBarProps {
 export default function PageBar({ title }: PageBarProps) {
   const { theme, toggleTheme } = useTheme();
   const { data: customer } = useGetCustomer();
-  if (!customer) { return <Skeleton></Skeleton> } else { console.log("this is the customer that you are looking for", customer) }
+  if (!customer) { return <Skeleton></Skeleton> }
   return (
     <AppBar color="transparent" position="static" elevation={0}>
       <Container maxWidth={false}>

--- a/nutrinova-ui/src/components/providers/QueryClientNextProvider.tsx
+++ b/nutrinova-ui/src/components/providers/QueryClientNextProvider.tsx
@@ -6,11 +6,12 @@ import { Toaster, toast } from "react-hot-toast";
 
 const queryClient = new QueryClient({
   queryCache: new QueryCache({
-    onError: async (error: unknown) => {
+    onError: async (error: Error) => {
       if (error instanceof Error) {
         if (error.message.includes("401")) {
           toast.error("You are not authorized to perform this action. Please sign out and in again.");
           await signOut();
+          return;
         }
         toast.error("There was an error with your request: " + error.message);
       } else {

--- a/nutrinova-ui/src/components/providers/QueryClientNextProvider.tsx
+++ b/nutrinova-ui/src/components/providers/QueryClientNextProvider.tsx
@@ -1,14 +1,16 @@
 'use client'
 import { QueryCache, QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { signOut } from 'next-auth/react';
 import React, { ReactNode } from 'react'
 import { Toaster, toast } from "react-hot-toast";
 
 const queryClient = new QueryClient({
   queryCache: new QueryCache({
-    onError: (error: unknown) => {
+    onError: async (error: unknown) => {
       if (error instanceof Error) {
         if (error.message.includes("401")) {
           toast.error("You are not authorized to perform this action. Please sign out and in again.");
+          await signOut();
         }
         toast.error("There was an error with your request: " + error.message);
       } else {

--- a/nutrinova-ui/src/services/axiosRequestFactory.ts
+++ b/nutrinova-ui/src/services/axiosRequestFactory.ts
@@ -5,33 +5,35 @@ import { getSession } from "next-auth/react";
 
 
 
+let singletonInstance: AxiosInstance | null = null;
+
 const createAuthenticatedAxiosInstanceFactory = async ({
   additionalHeaders = {},
   origin
-}
-  : {
-    additionalHeaders: object,
-    origin: "client" | "server"
-  }): Promise<AxiosInstance> => {
+}: {
+  additionalHeaders: object,
+  origin: "client" | "server"
+}): Promise<AxiosInstance> => {
+  if (singletonInstance) {
+    return singletonInstance;
+  }
 
   const session = origin === "client" ? await getSession() as Session : await getServerSession(options) as Session;
   if (!session.user.access_token) {
     throw new Error("Session not found or access token is missing");
   }
   const factoryHeaders = {
-
     Authorization: `Bearer ${session.user.access_token}`,
     ...additionalHeaders, // Merge any additional headers passed to the function
   };
 
   const url = origin === "client" ? "/be/" : process.env.NUTRINOVA_API_URL + "/be/"
-  const axiosInstance = axios.create(
-    {
-      baseURL: url,
-      headers: { ...factoryHeaders }
-    });
+  singletonInstance = axios.create({
+    baseURL: url,
+    headers: { ...factoryHeaders }
+  });
 
-  return axiosInstance;
+  return singletonInstance;
 }
 
 export default createAuthenticatedAxiosInstanceFactory;

--- a/nutrinova-ui/src/services/axiosRequestFactory.ts
+++ b/nutrinova-ui/src/services/axiosRequestFactory.ts
@@ -3,8 +3,6 @@ import axios, { AxiosInstance } from "axios";
 import { Session, getServerSession } from "next-auth";
 import { getSession } from "next-auth/react";
 
-
-
 let singletonInstance: AxiosInstance | null = null;
 
 const createAuthenticatedAxiosInstanceFactory = async ({
@@ -34,6 +32,10 @@ const createAuthenticatedAxiosInstanceFactory = async ({
   });
 
   return singletonInstance;
+}
+
+export const resetSingletonInstance = () => {
+  singletonInstance = null;
 }
 
 export default createAuthenticatedAxiosInstanceFactory;

--- a/nutrinova-ui/src/services/customerService.ts
+++ b/nutrinova-ui/src/services/customerService.ts
@@ -1,4 +1,4 @@
-import createAuthenticatedAxiosInstanceFactory from "./axiosRequestFactory";
+import createAuthenticatedAxiosInstanceFactory, { resetSingletonInstance } from "./axiosRequestFactory";
 import { getSession } from "next-auth/react";
 
 export interface Customer {
@@ -14,6 +14,7 @@ const fetchFromServer = async (url: string, origin: "client" | "server") => {
 }
 
 const postToServer = async (url: string, data: unknown) => {
+  resetSingletonInstance();
   const axiosInstance = await createAuthenticatedAxiosInstanceFactory({ additionalHeaders: { "Content-Type": "application/json" }, origin: "client" })
   const response = await axiosInstance.post(url, JSON.stringify(data));
   return response.data as unknown;

--- a/nutrinova-ui/types/next-auth.d.ts
+++ b/nutrinova-ui/types/next-auth.d.ts
@@ -56,6 +56,7 @@ declare global {
       KEYCLOAK_BASE_URL?: string
       NUTRINOVA_API_URL?: string
       WEBSOCKET_URL?: string
+      REFRESH_TOKEN_BUFFER_TIME_MINUTES?: number
     }
   }
 }


### PR DESCRIPTION
- I made the api client a singleton instance, because it was re fetching the session every time it was created for any api call. This made a significant difference in how many times session is called, especially before tanstack starts caching. This caused issues for creating patients for some reason, so I made a method to reset the singleton for that call specifically, and also when the token refreshes, so the api clients get the new token. 

- Removed the session provider because it wasnt being used anywhere, this also cleared up a session calls.

- Added a buffer to the refresh token timeout so it refreshes before it expires, not at the time it expires. There are still some issues with the browser not checking in the background, only when you return, so the page will go stale. Now that it signs you out in that case I think its ok. 